### PR TITLE
Convert plugin to headless JavaScript-only execution

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import './App.css';
 import {
   useConfig,
   useEditorPanelConfig,
@@ -22,7 +21,7 @@ function App() {
     triggerOnLoadAction();
   }, [triggerOnLoadAction]);
 
-  return <div style={{ backgroundColor: 'transparent' }}></div>;
+  return null;
 }
 
 export default App;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,5 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
## Summary
- Remove all visual rendering from the React plugin
- Plugin now returns `null` instead of UI components
- Remove CSS imports since no styling is needed
- Maintains JavaScript functionality for onLoad action triggering

## Test plan
- [ ] Verify plugin loads without rendering any UI elements
- [ ] Confirm onLoad action still triggers correctly
- [ ] Test that no CSS conflicts occur with host site